### PR TITLE
Remove trailing slash from server address which causes authentication failure

### DIFF
--- a/lib/features/login/bloc/authentication_cubit.dart
+++ b/lib/features/login/bloc/authentication_cubit.dart
@@ -31,6 +31,12 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
       await registerSecurityContext(clientCertificate);
       //TODO: Workaround for new architecture, listen for security context changes in timeout_client, possibly persisted in hive.
       _authApi = getIt<PaperlessAuthenticationApi>();
+
+      // Remove trailing slash from server address
+      if (serverUrl.endsWith('/')) {
+        serverUrl = serverUrl.substring(0, serverUrl.length - 1);
+      }
+
       // Store information required to make requests
       final currentAuth = AuthenticationInformation(
         serverUrl: serverUrl,


### PR DESCRIPTION
Hi,
I've tried to fix the issue I had in the following issue https://github.com/astubenbord/paperless-mobile/issues/56.

This change allows trailing slashes on server addresses without causing an authentication error in the app.

(As I'm new to flutter/dart I'm not sure if that's the right place to put the logic. I can change it if needed)

Regards
Etarus