### PR TITLE
[BUGFIX] Fixed crashing label page

### DIFF
--- a/lib/features/edit_label/view/add_label_page.dart
+++ b/lib/features/edit_label/view/add_label_page.dart
@@ -30,7 +30,12 @@ class AddLabelPage<T extends Label> extends StatelessWidget {
       ),
       child: AddLabelFormWidget(
         pageTitle: pageTitle,
-        label: initialName != null ? fromJsonT({'name': initialName}) : null,
+        label: initialName != null
+            ? fromJsonT({
+                'name': initialName,
+                'matching_algorithm': MatchingAlgorithm.auto.value
+              })
+            : null,
         additionalFields: additionalFields,
         fromJsonT: fromJsonT,
       ),


### PR DESCRIPTION
fixed crashing label page when adding new tag/consumer because `matchng_algorithm` is null