### PR TITLE
bugfix: Add missing languages to selectable options

### DIFF
--- a/lib/features/settings/view/pages/application_settings_page.dart
+++ b/lib/features/settings/view/pages/application_settings_page.dart
@@ -1,13 +1,8 @@
-import 'dart:developer';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/color_scheme_option_setting.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/language_selection_setting.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/theme_mode_setting.dart';
 import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
-
-import 'package:paperless_mobile/constants.dart';
 
 class ApplicationSettingsPage extends StatelessWidget {
   const ApplicationSettingsPage({super.key});

--- a/lib/features/settings/view/widgets/language_selection_setting.dart
+++ b/lib/features/settings/view/widgets/language_selection_setting.dart
@@ -18,6 +18,8 @@ class _LanguageSelectionSettingState extends State<LanguageSelectionSetting> {
     'de': 'Deutsch',
     'cs': 'Česky',
     'tr': 'Türkçe',
+    'fr': 'Français',
+    'pl': 'Polska',
   };
 
   @override
@@ -44,12 +46,20 @@ class _LanguageSelectionSettingState extends State<LanguageSelectionSetting> {
                   label: _languageOptions['de']!,
                 ),
                 RadioOption(
+                  value: 'fr',
+                  label: _languageOptions['fr']! + "*",
+                ),
+                RadioOption(
                   value: 'cs',
                   label: _languageOptions['cs']! + "*",
                 ),
                 RadioOption(
                   value: 'tr',
                   label: _languageOptions['tr']! + "*",
+                ),
+                RadioOption(
+                  value: 'pl',
+                  label: _languageOptions['pl']! + "*",
                 )
               ],
               initialValue: context


### PR DESCRIPTION
Add translations for language names of 'fr' and 'pl'.