### PR TITLE
Allow empty original_filename of document

### DIFF
--- a/lib/features/document_details/view/widgets/document_meta_data_widget.dart
+++ b/lib/features/document_details/view/widgets/document_meta_data_widget.dart
@@ -55,6 +55,12 @@ class _DocumentMetaDataWidgetState extends State<DocumentMetaDataWidget> {
                 context: context,
                 label: S.of(context)!.mediaFilename,
               ).paddedOnly(bottom: widget.itemSpacing),
+              if (state.document.originalFileName != null)
+                DetailsItem.text(
+                  state.document.originalFileName!,
+                  context: context,
+                  label: S.of(context)!.originalMD5Checksum,
+                ).paddedOnly(bottom: widget.itemSpacing),
               DetailsItem.text(
                 state.metaData!.originalChecksum,
                 context: context,

--- a/packages/paperless_api/lib/src/models/document_model.dart
+++ b/packages/paperless_api/lib/src/models/document_model.dart
@@ -36,7 +36,7 @@ class DocumentModel extends Equatable {
   final DateTime modified;
   final DateTime added;
   final int? archiveSerialNumber;
-  final String originalFileName;
+  final String? originalFileName;
   final String? archivedFileName;
 
   @JsonKey(
@@ -62,7 +62,7 @@ class DocumentModel extends Equatable {
     required this.modified,
     required this.added,
     this.archiveSerialNumber,
-    required this.originalFileName,
+    this.originalFileName,
     this.archivedFileName,
     this.storagePath,
     this.searchHit,


### PR DESCRIPTION
My paperless instance has documents with an empty (null) original_filename.
Maybe they have been added through this paperless mobile app, but I am not sure.
Retrieving these documents via the app gave an error when deserializing (not visible in the UI, but got it during debugging).
This PR fixes it to allow a null originalFileName.