### PR TITLE
feat: Make install_dependencies.sh script more robust

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,12 +1,23 @@
-#!/bin/bash
-pushd ../
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+__script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+readonly __script_dir
+
+pushd "$__script_dir/../"
+
 pushd packages/paperless_api
 flutter packages pub get
 dart run build_runner build --delete-conflicting-outputs
 popd
+
 pushd packages/mock_server
 flutter packages pub get
 popd
+
 flutter packages pub get
 flutter gen-l10n
 dart run build_runner build --delete-conflicting-outputs
+
+popd
+


### PR DESCRIPTION
This PR modifies the dependencies installer script to make it more robust, meaning that it works even when invoked from other directories than `scripts/`.