### PR TITLE
Add improved error message for scanner page's upload button

### DIFF
--- a/lib/features/document_scan/view/scanner_page.dart
+++ b/lib/features/document_scan/view/scanner_page.dart
@@ -154,6 +154,7 @@ class _ScannerPageState extends State<ScannerPage>
                       );
                     },
                     disabled: state.scans.isEmpty,
+                    disabledReason: S.of(context)!.noDocumentsScanned,
                     child: TextButton.icon(
                       label: Text(S.of(context)!.upload),
                       style: TextButton.styleFrom(

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "Du hast noch keine Dokumente gescannt."
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1001,5 +1001,6 @@
   "@discardChangesWarning": {
     "description": "Warning message shown when the user tries to close a route without saving the changes."
   },
-  "changelog": "Changelog"
+  "changelog": "Changelog",
+  "noDocumentsScanned": "You have not scanned any documents yet."
 }


### PR DESCRIPTION
Fixes #280 
There's already a `noDocumentsScanned` translation key. But since ones an error and the other a hint I prefer having different keys for that.