### PR TITLE
Update README.md: fix section Contributors rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ If you wish to support the development of this project, you can donate through G
 <a href="https://github.com/astubenbord/paperless-mobile/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=astubenbord/paperless-mobile" />
 </a>
+
 Made with [contrib.rocks](https://contrib.rocks).
 
 Want to contribute? Have a look at [the contributing guidelines and how to get started](https://github.com/astubenbord/paperless-mobile/blob/development/CONTRIBUTING.md).


### PR DESCRIPTION
fix link rendering in section 'Contributors'

before:
![image](https://github.com/astubenbord/paperless-mobile/assets/25772356/ac9421db-dd8e-49b5-ae7d-de9f019faccc)

after:
![image](https://github.com/astubenbord/paperless-mobile/assets/25772356/200d4431-f367-42c5-b981-a1f2af24010a)
