### PR TITLE
enhancements in android keyboard interaction

### DIFF
--- a/lib/features/document_edit/view/document_edit_page.dart
+++ b/lib/features/document_edit/view/document_edit_page.dart
@@ -305,6 +305,7 @@ class _DocumentEditPageState extends State<DocumentEditPage>
                   name: fkContent,
                   maxLines: null,
                   keyboardType: TextInputType.multiline,
+                  enableSuggestions: true,
                   initialValue: state.document.content,
                   decoration: const InputDecoration(
                     border: InputBorder.none,
@@ -403,6 +404,7 @@ class _DocumentEditPageState extends State<DocumentEditPage>
   Widget _buildTitleFormField(String? initialTitle) {
     return FormBuilderTextField(
       name: fkTitle,
+      enableSuggestions: true,
       decoration: InputDecoration(
         label: Text(S.of(context)!.title),
         suffixIcon: IconButton(

--- a/lib/features/document_upload/view/document_upload_preparation_page.dart
+++ b/lib/features/document_upload/view/document_upload_preparation_page.dart
@@ -142,6 +142,7 @@ class _DocumentUploadPreparationPageState
                             // Title
                             FormBuilderTextField(
                               autovalidateMode: AutovalidateMode.always,
+                              enableSuggestions: true,
                               name: DocumentModel.titleKey,
                               initialValue: widget.title ??
                                   "scan_${fileNameDateFormat.format(_now)}",
@@ -179,6 +180,7 @@ class _DocumentUploadPreparationPageState
                             // Filename
                             FormBuilderTextField(
                               autovalidateMode: AutovalidateMode.always,
+                              enableSuggestions: true,
                               readOnly: _syncTitleAndFilename,
                               enabled: !_syncTitleAndFilename,
                               name: fkFileName,

--- a/lib/features/edit_label/view/label_form.dart
+++ b/lib/features/edit_label/view/label_form.dart
@@ -86,6 +86,7 @@ class _LabelFormState<T extends Label> extends State<LabelForm<T>> {
           children: [
             FormBuilderTextField(
               autofocus: widget.autofocusNameField,
+              enableSuggestions: true,
               name: Label.nameKey,
               decoration: InputDecoration(
                 labelText: S.of(context)!.name,
@@ -130,6 +131,7 @@ class _LabelFormState<T extends Label> extends State<LabelForm<T>> {
             if (_enableMatchFormField)
               FormBuilderTextField(
                 name: Label.matchKey,
+                enableSuggestions: true,
                 decoration: InputDecoration(
                   labelText: S.of(context)!.match,
                   errorText: _errors[Label.matchKey],

--- a/lib/features/login/view/widgets/form_fields/user_credentials_form_field.dart
+++ b/lib/features/login/view/widgets/form_fields/user_credentials_form_field.dart
@@ -37,7 +37,7 @@ class _UserCredentialsFormFieldState extends State<UserCredentialsFormField>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return FormBuilderField<LoginFormCredentials?>(
+    return AutofillGroup(child: FormBuilderField<LoginFormCredentials?>(
       initialValue: LoginFormCredentials(
         password: widget.initialPassword,
         username: widget.initialUsername,
@@ -100,47 +100,9 @@ class _UserCredentialsFormFieldState extends State<UserCredentialsFormField>
           ),
         ].map((child) => child.padded()).toList(),
       ),
-    );
+    ));
   }
 
   @override
   bool get wantKeepAlive => true;
 }
-
-/**
- * AutofillGroup(
-      child: Column(
-        children: [
-          FormBuilderTextField(
-            name: fkUsername,
-            focusNode: _focusNodes[fkUsername],
-            onSubmitted: (_) {
-              FocusScope.of(context).requestFocus(_focusNodes[fkPassword]);
-            },
-            validator: FormBuilderValidators.required(
-              errorText: S.of(context)!.usernameMustNotBeEmpty,
-            ),
-            autofillHints: const [AutofillHints.username],
-            decoration: InputDecoration(
-              labelText: S.of(context)!.username,
-            ),
-          ).padded(),
-          FormBuilderTextField(
-            name: fkPassword,
-            focusNode: _focusNodes[fkPassword],
-            onSubmitted: (_) {
-              FocusScope.of(context).unfocus();
-            },
-            autofillHints: const [AutofillHints.password],
-            validator: FormBuilderValidators.required(
-              errorText: S.of(context)!.passwordMustNotBeEmpty,
-            ),
-            obscureText: true,
-            decoration: InputDecoration(
-              labelText: S.of(context)!.password,
-            ),
-          ).padded(),
-        ],
-      ),
-    );
- */

--- a/lib/features/saved_view/view/add_saved_view_page.dart
+++ b/lib/features/saved_view/view/add_saved_view_page.dart
@@ -52,6 +52,7 @@ class _AddSavedViewPageState extends State<AddSavedViewPage> {
                 children: [
                   FormBuilderTextField(
                     name: _fkName,
+                    enableSuggestions: true,
                     validator: (value) {
                       if (value?.trim().isEmpty ?? true) {
                         return S.of(context)!.thisFieldIsRequired;

--- a/lib/features/saved_view/view/edit_saved_view_page.dart
+++ b/lib/features/saved_view/view/edit_saved_view_page.dart
@@ -47,6 +47,7 @@ class _EditSavedViewPageState extends State<EditSavedViewPage> {
                 children: [
                   FormBuilderTextField(
                     initialValue: widget.savedView.name,
+                    enableSuggestions: true,
                     name: _fkName,
                     validator: (value) {
                       if (value?.trim().isEmpty ?? true) {


### PR DESCRIPTION
this PR introduces two enhancements related to how the app interacts with the on-screen keyboard on android devices.

## 1. enable suggestions in form fields

currently, form fields (e.g. the title field when uploading a new document) do __not__ show any suggestions while typing. 
this means that there's no autocorrect and [swipe typing](https://support.google.com/gboard/answer/2811346) is rendered completely useless.

this is caused by the `FormBuilderTextField`'s `enableSuggestions` property being set to `false`. 
since the [docs](https://pub.dev/documentation/flutter_form_builder/latest/flutter_form_builder/FormBuilderTextField/enableSuggestions.html) don't mention a default value for this property, i'm assuming that the default is simply `false`.

explicitely setting `enableSuggestions` to `true` makes the suggestions work (see Fig. A), so i simply added it to all uses of the `FormBuilderTextField`. 
This includes (but may not be limited to):
- the 'Title' and 'File Name' fields when uploading a new document
- the 'Title' field when editing a document
- the 'Name' fields when creating a new correspondent, document type, or label


## 2. enable autofill of user credentials in login form

this one is quite simple because i've just added an `AutofillGroup` wrapping the `FormBuilderField` of the user credentials form shown when adding a new user. 
This makes autofill suggestions show up on the keyboard normally (see Fig. B).



 ![upload-doc-suggestions](https://github.com/astubenbord/paperless-mobile/assets/52449218/a379c4fd-c82b-468c-a16a-9b14f62863fe) | ![login-autofill-1](https://github.com/astubenbord/paperless-mobile/assets/52449218/d2f308bd-e558-4514-bb1a-8edc27739c0e)
-|-
(Fig. A) GBoard showing suggestions for 'Title' field on document upload | (Fig. B) GBoard showing autofill options on login (Bitwarden). Clicking the entry will autofill the credentials in the app.


