### PR TITLE
Enhance filename and display name synchronization on document upload

### DIFF
--- a/lib/features/document_upload/view/document_upload_preparation_page.dart
+++ b/lib/features/document_upload/view/document_upload_preparation_page.dart
@@ -55,6 +55,11 @@ class _DocumentUploadPreparationPageState
     extends State<DocumentUploadPreparationPage> {
   static const fkFileName = "filename";
   static final fileNameDateFormat = DateFormat("yyyy_MM_ddTHH_mm_ss");
+  static final Map<String, String> fileNameReplacements = {
+    'ä': 'ae', 'ö': 'oe', 'ü': 'ue', 'ß': 'ss', 'à': 'a', 'â': 'a', 'ç': 'c', 'é': 'e', 'è': 'e', 'ê': 'e', 'á': 'a', 'í': 'i', 'ó': 'o', 'ú': 'u', 'ñ': 'n', 'ì': 'i', 'ò': 'o', 'ù': 'u', 'ã': 'a', 'õ': 'o'
+  };
+  static final RegExp fileNameReplacementPattern = RegExp('[${fileNameReplacements.keys.join()}]');
+  
 
   final GlobalKey<FormBuilderState> _formKey = GlobalKey();
   Map<String, String> _errors = {};
@@ -378,7 +383,9 @@ class _DocumentUploadPreparationPageState
   }
 
   String _formatFilename(String source) {
-    return source.replaceAll(RegExp(r"[\W_]"), "_").toLowerCase();
+    return source
+        .replaceAllMapped(fileNameReplacementPattern, (match) => fileNameReplacements[match.group(0)]!);
+        .replaceAll(RegExp(r"[\W_]"), "_").toLowerCase();
   }
 
   // Future<Color> _computeAverageColor() async {

--- a/lib/features/document_upload/view/document_upload_preparation_page.dart
+++ b/lib/features/document_upload/view/document_upload_preparation_page.dart
@@ -384,8 +384,9 @@ class _DocumentUploadPreparationPageState
 
   String _formatFilename(String source) {
     return source
+        .toLowerCase()
         .replaceAllMapped(fileNameReplacementPattern, (match) => fileNameReplacements[match.group(0)]!);
-        .replaceAll(RegExp(r"[\W_]"), "_").toLowerCase();
+        .replaceAll(RegExp(r"[\W_]"), "_");
   }
 
   // Future<Color> _computeAverageColor() async {


### PR DESCRIPTION
When uploading files, you can already synchronize the file name with the display name. The pattern '[\W_]' is currently used to replace all non-word characters with '_'. However, this procedure also replaces umlauts or other letters with accents. I have therefore extended the previous process so that umlauts and letters with accents are replaced accordingly. For the replacement rule for letters with accents, I have relied on 'source internet', as I do not speak all languages.

What's not particularly nice about the current solution is that 'toLowerCase()' and the two RegEx run over the filename a total of three times. If anyone has a better solution, please let me know :)