### PR TITLE
fix removing single file from scanned pages

### DIFF
--- a/lib/features/document_scan/cubit/document_scanner_cubit.dart
+++ b/lib/features/document_scan/cubit/document_scanner_cubit.dart
@@ -64,7 +64,7 @@ class DocumentScannerCubit extends Cubit<DocumentScannerState> {
         stackTrace: stackTrace,
       );
     }
-    final scans = state.scans..remove(file);
+    final scans = state.scans.where((f) => f != file).toList();
     emit(
       scans.isEmpty
           ? const DocumentScannerState()


### PR DESCRIPTION
Removing a single file from scanned pages failed with UnmodifiableListMixin.remove (dart:_internal/list.dart:134)

This filters the list instead of trying to remove from it.

fixes #395
Signed-off-by: Jörg Vehlow <joerg@jv-coder.de>