### PR TITLE
feat: add TOTP/MFA support for login flow

### DIFF
--- a/lib/features/login/cubit/authentication_cubit.dart
+++ b/lib/features/login/cubit/authentication_cubit.dart
@@ -85,6 +85,21 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
               AuthenticatingStage.persistingLocalUserData));
         },
       );
+    } on PaperlessMfaRequiredException catch (_) {
+      logger.fd(
+        "MFA required for $redactedId, prompting for TOTP code...",
+        className: runtimeType.toString(),
+        methodName: 'login',
+      );
+      emit(
+        MfaRequiredState(
+          serverUrl: serverUrl,
+          username: credentials.username!,
+          password: credentials.password!,
+          clientCertificate: clientCertificate,
+        ),
+      );
+      return;
     } on PaperlessApiException catch (_) {
       emit(
         AuthenticationErrorState(
@@ -112,6 +127,48 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
   }
 
   /// Switches to another account if it exists.
+  Future<void> loginWithMfa({
+    required String username,
+    required String password,
+    required String serverUrl,
+    required String totpCode,
+    ClientCertificate? clientCertificate,
+  }) async {
+    final localUserId = "$username@$serverUrl";
+    final redactedId = redactUserId(localUserId);
+
+    logger.fd(
+      "Trying to log in $redactedId with MFA...",
+      className: runtimeType.toString(),
+      methodName: 'loginWithMfa',
+    );
+    // Do not emit AuthenticatingState or AuthenticationErrorState here;
+    // the TOTP dialog manages its own loading/error UI.
+    await _addUser(
+      localUserId,
+      serverUrl,
+      LoginFormCredentials(
+        username: username,
+        password: password,
+      ),
+      clientCertificate,
+      _sessionManager,
+      totpCode: totpCode,
+    );
+
+    final globalSettings =
+        Hive.box<GlobalSettings>(HiveBoxes.globalSettings).getValue()!;
+    globalSettings.loggedInUserId = localUserId;
+    await globalSettings.save();
+
+    emit(AuthenticatedState(localUserId: localUserId));
+    logger.fd(
+      'User $redactedId successfully logged in with MFA.',
+      className: runtimeType.toString(),
+      methodName: 'loginWithMfa',
+    );
+  }
+
   Future<void> switchAccount(String localUserId) async {
     emit(const SwitchingAccountsState());
     await FileService.instance.initialize();
@@ -447,6 +504,7 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
     _FutureVoidCallback? onPerformLogin,
     _FutureVoidCallback? onPersistLocalUserData,
     _FutureVoidCallback? onFetchUserInformation,
+    String? totpCode,
   }) async {
     assert(credentials.username != null && credentials.password != null);
     final redactedId = redactUserId(localUserId);
@@ -473,6 +531,7 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
     final token = await authApi.login(
       username: credentials.username!,
       password: credentials.password!,
+      totpCode: totpCode,
     );
 
     logger.fd(

--- a/lib/features/login/cubit/authentication_state.dart
+++ b/lib/features/login/cubit/authentication_state.dart
@@ -50,6 +50,23 @@ class SwitchingAccountsState extends AuthenticationState {
   const SwitchingAccountsState();
 }
 
+class MfaRequiredState extends AuthenticationState with EquatableMixin {
+  final String serverUrl;
+  final String username;
+  final String password;
+  final ClientCertificate? clientCertificate;
+
+  const MfaRequiredState({
+    required this.serverUrl,
+    required this.username,
+    required this.password,
+    this.clientCertificate,
+  });
+
+  @override
+  List<Object?> get props => [serverUrl, username, password, clientCertificate];
+}
+
 class AuthenticationErrorState extends AuthenticationState with EquatableMixin {
   final ErrorCode? errorCode;
   final String serverUrl;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -289,6 +289,132 @@ class _GoRouterShellState extends State<GoRouterShell> {
     await FlutterDisplayMode.setPreferredMode(mostOptimalMode);
   }
 
+  void _showTotpDialog(BuildContext context, MfaRequiredState mfaState) {
+    final totpController = TextEditingController();
+    var isSubmitting = false;
+
+    Future<void> submitTotp(
+      BuildContext dialogContext,
+      void Function(void Function()) setDialogState,
+    ) async {
+      final code = totpController.text.trim();
+      if (code.isEmpty || code.length < 6) {
+        return;
+      }
+      setDialogState(() => isSubmitting = true);
+      try {
+        await context.read<AuthenticationCubit>().loginWithMfa(
+              username: mfaState.username,
+              password: mfaState.password,
+              serverUrl: mfaState.serverUrl,
+              totpCode: code,
+              clientCertificate: mfaState.clientCertificate,
+            );
+        if (dialogContext.mounted) {
+          Navigator.of(dialogContext).pop();
+        }
+      } on PaperlessApiException catch (error) {
+        setDialogState(() => isSubmitting = false);
+        if (dialogContext.mounted) {
+          ScaffoldMessenger.of(dialogContext)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                behavior: SnackBarBehavior.floating,
+                content: Text(error.details ?? 'Authentication failed'),
+              ),
+            );
+        }
+      } on PaperlessFormValidationException catch (error) {
+        setDialogState(() => isSubmitting = false);
+        if (dialogContext.mounted) {
+          ScaffoldMessenger.of(dialogContext)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                behavior: SnackBarBehavior.floating,
+                content: Text(
+                  error.unspecificErrorMessage() ?? 'Invalid code',
+                ),
+              ),
+            );
+        }
+      } catch (error) {
+        setDialogState(() => isSubmitting = false);
+        if (dialogContext.mounted) {
+          ScaffoldMessenger.of(dialogContext)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                behavior: SnackBarBehavior.floating,
+                content: Text(error.toString()),
+              ),
+            );
+        }
+      }
+    }
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: const Text('Two-Factor Authentication'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Your account is protected by two-factor authentication. '
+                    'Please enter the code from your authenticator app.',
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: totpController,
+                    autofocus: true,
+                    keyboardType: TextInputType.number,
+                    maxLength: 6,
+                    decoration: const InputDecoration(
+                      labelText: 'TOTP Code',
+                      hintText: '000000',
+                      border: OutlineInputBorder(),
+                      counterText: '',
+                    ),
+                    onSubmitted: isSubmitting
+                        ? null
+                        : (_) => submitTotp(dialogContext, setDialogState),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: isSubmitting
+                      ? null
+                      : () => Navigator.of(dialogContext).pop(),
+                  child: const Text('Cancel'),
+                ),
+                FilledButton(
+                  onPressed: isSubmitting
+                      ? null
+                      : () => submitTotp(dialogContext, setDialogState),
+                  child: isSubmitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Verify'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
   late final _router = GoRouter(
     debugLogDiagnostics: kDebugMode,
     initialLocation: "/login",
@@ -333,6 +459,12 @@ class _GoRouterShellState extends State<GoRouterShell> {
                       if (context.canPop()) {
                         context.pop();
                       }
+                      break;
+                    case MfaRequiredState():
+                      if (context.canPop()) {
+                        context.pop();
+                      }
+                      _showTotpDialog(context, state);
                       break;
                   }
                 },

--- a/packages/paperless_api/lib/src/models/exception/exceptions.dart
+++ b/packages/paperless_api/lib/src/models/exception/exceptions.dart
@@ -1,3 +1,4 @@
 export 'paperless_server_message_exception.dart';
 export 'paperless_form_validation_exception.dart';
 export 'paperless_unauthorized_exception.dart';
+export 'paperless_mfa_required_exception.dart';

--- a/packages/paperless_api/lib/src/models/exception/paperless_mfa_required_exception.dart
+++ b/packages/paperless_api/lib/src/models/exception/paperless_mfa_required_exception.dart
@@ -1,0 +1,10 @@
+/// Exception thrown when the server requires a TOTP/MFA code to complete
+/// authentication.
+class PaperlessMfaRequiredException implements Exception {
+  final String message;
+
+  PaperlessMfaRequiredException([this.message = 'MFA code is required']);
+
+  @override
+  String toString() => 'PaperlessMfaRequiredException: $message';
+}

--- a/packages/paperless_api/lib/src/modules/authentication_api/authentication_api.dart
+++ b/packages/paperless_api/lib/src/modules/authentication_api/authentication_api.dart
@@ -2,5 +2,6 @@ abstract class PaperlessAuthenticationApi {
   Future<String> login({
     required String username,
     required String password,
+    String? totpCode,
   });
 }

--- a/packages/paperless_api/lib/src/modules/authentication_api/authentication_api_impl.dart
+++ b/packages/paperless_api/lib/src/modules/authentication_api/authentication_api_impl.dart
@@ -11,14 +11,19 @@ class PaperlessAuthenticationApiImpl implements PaperlessAuthenticationApi {
   Future<String> login({
     required String username,
     required String password,
+    String? totpCode,
   }) async {
     try {
+      final data = <String, dynamic>{
+        "username": username,
+        "password": password,
+      };
+      if (totpCode != null) {
+        data["code"] = totpCode;
+      }
       final response = await client.post(
         "/api/token/",
-        data: {
-          "username": username,
-          "password": password,
-        },
+        data: data,
         options: Options(
           sendTimeout: const Duration(seconds: 5),
           receiveTimeout: const Duration(seconds: 5),
@@ -26,16 +31,18 @@ class PaperlessAuthenticationApiImpl implements PaperlessAuthenticationApi {
           headers: {
             "Accept": "application/json",
           },
-          // validateStatus: (status) {
-          //   return status! == 200;
-          // },
         ),
       );
       return response.data['token'];
-      // } else if (response.statusCode == 302) {
-      // final redirectUrl = response.headers.value("location");
-      // return AuthenticationTemporaryRedirect(redirectUrl!);
     } on DioException catch (exception) {
+      final error = exception.error;
+      if (error is PaperlessFormValidationException) {
+        final message = error.unspecificErrorMessage();
+        if (message != null &&
+            message.contains('MFA code is required')) {
+          throw PaperlessMfaRequiredException();
+        }
+      }
       throw exception.unravel();
     } catch (error, stackTrace) {
       throw PaperlessApiException.unknown(


### PR DESCRIPTION
When a paperless-ngx account has TOTP two-factor authentication enabled, the app now prompts for the 6-digit code instead of showing a generic 'MFA is required' error and hanging.

Changes:
- Add PaperlessMfaRequiredException for detecting MFA-required responses
- Pass optional 'code' field to POST /api/token/ when TOTP is provided
- Add MfaRequiredState to authentication state machine
- Add loginWithMfa() cubit method that skips navigation state emissions so the TOTP dialog can manage its own loading/error UI
- Show TOTP entry dialog from BlocListener when MFA is required
- Handle invalid code errors with inline SnackBar feedback and retry