### PR TITLE
Add bulk share/download/delete actions in Documents tab

### DIFF
--- a/lib/core/repository/document_repository.dart
+++ b/lib/core/repository/document_repository.dart
@@ -114,8 +114,7 @@ class DocumentRepository with ChangeNotifierMixin {
   }
 
   Future<BulkDownload> bulkDownload(BulkDownloadRequest request) {
-    // TODO: implement bulkDownload
-    throw UnimplementedError();
+    return _api.bulkDownload(request);
   }
 
   Mutation<int?, AssignAsnRequest> assignAsnMutation(int documentId) {
@@ -158,7 +157,7 @@ class DocumentRepository with ChangeNotifierMixin {
   }
 
   Mutation<BulkEditDocumentsResult, BulkEditRequest>
-  bulkEditDocumentsMutation() {
+      bulkEditDocumentsMutation() {
     return Mutation<BulkEditDocumentsResult, BulkEditRequest>(
       key: 'bulk_edit_documents',
       mutationFn: (arg) {
@@ -392,8 +391,7 @@ class DocumentRepository with ChangeNotifierMixin {
     final metadata = metadataResult.data!;
     final document = documentResult.data!;
 
-    final effectiveFilePath =
-        document.archivedFileName ??
+    final effectiveFilePath = document.archivedFileName ??
         document.originalFileName ??
         metadata.mediaFilename;
     if (effectiveFilePath == null) {

--- a/lib/features/documents/view/pages/documents_page.dart
+++ b/lib/features/documents/view/pages/documents_page.dart
@@ -281,7 +281,9 @@ class _DocumentsPageState extends State<DocumentsPage> {
                             if (_showExtendedFab)
                               Text(
                                 "Reset (${context.currentDocumentFilter$.appliedFiltersCount})", //TODO: INTL
-                                style: Theme.of(context).textTheme.labelLarge
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .labelLarge
                                     ?.copyWith(
                                       color: Theme.of(
                                         context,
@@ -333,8 +335,7 @@ class _DocumentsPageState extends State<DocumentsPage> {
         final query = context.documentRepository.getAllQuery(
           filter: context.currentDocumentFilter,
         );
-        final isLastPageLoaded =
-            query.state.data?.pages.fold(
+        final isLastPageLoaded = query.state.data?.pages.fold(
               0,
               (value, element) => value + element.results.length,
             ) ==
@@ -375,9 +376,7 @@ class _DocumentsPageState extends State<DocumentsPage> {
                       controller: _savedViewsExpansionController,
                       onViewSelected: (view) {
                         if (userData
-                                .appState
-                                .currentDocumentFilter
-                                .selectedView ==
+                                .appState.currentDocumentFilter.selectedView ==
                             view.id) {
                           _onResetFilter();
                         } else {
@@ -441,7 +440,7 @@ class _DocumentsPageState extends State<DocumentsPage> {
                     }
                     final documents =
                         state.data?.pages.expand((p) => p.results).toList() ??
-                        [];
+                            [];
                     final allowToggleFilter = _selection.isEmpty;
                     final viewType = userData.appState.documentsPageViewType;
 
@@ -467,18 +466,14 @@ class _DocumentsPageState extends State<DocumentsPage> {
                           });
                         }
                       },
-                      onTagSelected: allowToggleFilter
-                          ? _toggleTagInFilter
-                          : null,
-                      onCorrespondentSelected: allowToggleFilter
-                          ? _addCorrespondentToFilter
-                          : null,
-                      onDocumentTypeSelected: allowToggleFilter
-                          ? _addDocumentTypeToFilter
-                          : null,
-                      onStoragePathSelected: allowToggleFilter
-                          ? _addStoragePathToFilter
-                          : null,
+                      onTagSelected:
+                          allowToggleFilter ? _toggleTagInFilter : null,
+                      onCorrespondentSelected:
+                          allowToggleFilter ? _addCorrespondentToFilter : null,
+                      onDocumentTypeSelected:
+                          allowToggleFilter ? _addDocumentTypeToFilter : null,
+                      onStoragePathSelected:
+                          allowToggleFilter ? _addStoragePathToFilter : null,
                       documents: documents,
                       hasLoaded: state.data != null,
                       isLabelClickable: true,
@@ -501,9 +496,10 @@ class _DocumentsPageState extends State<DocumentsPage> {
       padding: const EdgeInsets.all(4),
       color: Theme.of(context).colorScheme.surface,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           SortDocumentsButton(enabled: _selection.isEmpty),
+          const Spacer(),
+          if (_selection.isEmpty) _buildSelectAllFilteredButton(),
           CurrentUserAppDataBuilder(
             builder: (context, userData) {
               final viewType = userData.appState.documentsPageViewType;
@@ -520,6 +516,33 @@ class _DocumentsPageState extends State<DocumentsPage> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildSelectAllFilteredButton() {
+    return CurrentUserAppDataBuilder(
+      builder: (context, userData) {
+        final filter = userData.appState.currentDocumentFilter;
+        final hasFilter =
+            filter.appliedFiltersCount > 0 || filter.selectedView != null;
+        if (!hasFilter) {
+          return const SizedBox.shrink();
+        }
+        return QueryBuilder(
+          query: context.documentRepository.getAllQuery(filter: filter),
+          builder: (context, state) {
+            final hasDocuments = (state.data?.firstPage?.count ?? 0) > 0;
+            if (!hasDocuments && !state.isLoading) {
+              return const SizedBox.shrink();
+            }
+            return IconButton(
+              tooltip: S.of(context)!.select,
+              icon: const Icon(Icons.select_all),
+              onPressed: hasDocuments ? _onSelectAllFilteredDocuments : null,
+            );
+          },
+        );
+      },
     );
   }
 
@@ -603,6 +626,54 @@ class _DocumentsPageState extends State<DocumentsPage> {
     );
   }
 
+  Future<void> _onSelectAllFilteredDocuments() async {
+    final query = context.documentRepository.getAllQuery(
+      filter: context.currentDocumentFilter,
+    );
+    try {
+      var previousLoadedCount = -1;
+      while (mounted) {
+        final data = query.state.data;
+        if (data == null) {
+          return;
+        }
+        final loadedCount = data.pages.fold<int>(
+          0,
+          (count, page) => count + page.results.length,
+        );
+        final totalCount = data.firstPage?.count ?? 0;
+        if (totalCount == 0 || loadedCount >= totalCount) {
+          break;
+        }
+        if (previousLoadedCount == loadedCount) {
+          break;
+        }
+        previousLoadedCount = loadedCount;
+        await query.getNextPage();
+      }
+      if (!mounted) {
+        return;
+      }
+      final selected = query.state.data?.pages.expand((p) => p.results).toSet();
+      if ((selected?.isEmpty ?? true)) {
+        return;
+      }
+      setState(() {
+        _selection
+          ..clear()
+          ..addAll(selected!);
+      });
+    } on PaperlessApiException catch (error, stackTrace) {
+      if (mounted) {
+        showErrorMessage(context, error, stackTrace);
+      }
+    } catch (error) {
+      if (mounted) {
+        showGenericError(context, error);
+      }
+    }
+  }
+
   ///
   /// Resets the current filter and scrolls all the way to the top of the view.
   /// If a saved view is currently selected and the filter has changed,
@@ -617,13 +688,10 @@ class _DocumentsPageState extends State<DocumentsPage> {
       );
     }
 
-    final activeView = context.savedViewRepository
-        .getAllQuery()
-        .state
-        .data
-        ?.firstWhereOrNull(
-          (view) => view.id == context.currentDocumentFilter.selectedView,
-        );
+    final activeView =
+        context.savedViewRepository.getAllQuery().state.data?.firstWhereOrNull(
+              (view) => view.id == context.currentDocumentFilter.selectedView,
+            );
 
     void reset() {
       context.localStore.updateLoggedInUserAppState(
@@ -631,12 +699,10 @@ class _DocumentsPageState extends State<DocumentsPage> {
       );
     }
 
-    final viewHasChanged =
-        activeView != null &&
+    final viewHasChanged = activeView != null &&
         activeView.toDocumentFilter() != context.currentDocumentFilter;
     if (viewHasChanged) {
-      final discardChanges =
-          await showDialog<bool>(
+      final discardChanges = await showDialog<bool>(
             useRootNavigator: false,
             context: context,
             builder: (context) => const SavedViewChangedDialog(),

--- a/lib/features/documents/view/widgets/selection/bulk_delete_confirmation_dialog.dart
+++ b/lib/features/documents/view/widgets/selection/bulk_delete_confirmation_dialog.dart
@@ -7,26 +7,39 @@ import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
 class BulkDeleteConfirmationDialog extends StatelessWidget {
   const BulkDeleteConfirmationDialog({super.key, required this.selection});
   final Iterable<Document> selection;
+  static const int _maxPreviewItems = 8;
+
   @override
   Widget build(BuildContext context) {
-    assert(selection.isNotEmpty);
+    final selectedDocuments = selection.toList(growable: false);
+    assert(selectedDocuments.isNotEmpty);
+    final previewItems = selectedDocuments.take(_maxPreviewItems).toList();
+    final remainingItems = selectedDocuments.length - previewItems.length;
+
     return AlertDialog(
       title: Text(S.of(context)!.confirmDeletion),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            S
-                .of(context)!
-                .areYouSureYouWantToDeleteTheFollowingDocuments(
-                  selection.length,
-                ),
-          ),
-          const SizedBox(height: 16),
-          ...selection.map(_buildBulletPoint),
-          const SizedBox(height: 16),
-          Text(S.of(context)!.thisActionIsIrreversibleDoYouWishToProceedAnyway),
-        ],
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              S.of(context)!.areYouSureYouWantToDeleteTheFollowingDocuments(
+                    selectedDocuments.length,
+                  ),
+            ),
+            const SizedBox(height: 16),
+            ...previewItems.map(_buildBulletPoint),
+            if (remainingItems > 0)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text('+$remainingItems ${S.of(context)!.documents}'),
+              ),
+            const SizedBox(height: 16),
+            Text(
+              S.of(context)!.thisActionIsIrreversibleDoYouWishToProceedAnyway,
+            ),
+          ],
+        ),
       ),
       actions: [
         const DialogCancelButton(),

--- a/lib/features/documents/view/widgets/selection/bulk_download_target_directory_dialog.dart
+++ b/lib/features/documents/view/widgets/selection/bulk_download_target_directory_dialog.dart
@@ -1,0 +1,92 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:paperless_mobile/core/widgets/dialog_utils/dialog_cancel_button.dart';
+import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
+
+class BulkDownloadTargetDirectoryDialog extends StatefulWidget {
+  final String initialDirectoryPath;
+  final int documentsCount;
+
+  const BulkDownloadTargetDirectoryDialog({
+    super.key,
+    required this.initialDirectoryPath,
+    required this.documentsCount,
+  });
+
+  @override
+  State<BulkDownloadTargetDirectoryDialog> createState() =>
+      _BulkDownloadTargetDirectoryDialogState();
+}
+
+class _BulkDownloadTargetDirectoryDialogState
+    extends State<BulkDownloadTargetDirectoryDialog> {
+  late String _directoryPath = widget.initialDirectoryPath;
+  bool _isSelectingDirectory = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(S.of(context)!.downloadDocumentTooltip),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(S.of(context)!.countSelected(widget.documentsCount)),
+          const SizedBox(height: 8),
+          Text(
+            S.of(context)!.storagePath,
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _directoryPath,
+            maxLines: 4,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: _isSelectingDirectory ? null : _onSelectDirectory,
+            icon: const Icon(Icons.folder_open),
+            label: Text(S.of(context)!.select),
+          ),
+        ],
+      ),
+      actions: [
+        const DialogCancelButton(),
+        ElevatedButton(
+          onPressed: _directoryPath.trim().isEmpty
+              ? null
+              : () => Navigator.of(context).pop(_directoryPath.trim()),
+          child: Text(S.of(context)!.save),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _onSelectDirectory() async {
+    setState(() {
+      _isSelectingDirectory = true;
+    });
+    try {
+      final path = await FilePicker.platform.getDirectoryPath(
+        initialDirectory: _directoryPath,
+        dialogTitle: S.of(context)!.storagePath,
+      );
+      if (path == null || path.trim().isEmpty || !mounted) {
+        return;
+      }
+      setState(() {
+        _directoryPath = path;
+      });
+    } catch (_) {
+      return;
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSelectingDirectory = false;
+        });
+      }
+    }
+  }
+}

--- a/lib/features/documents/view/widgets/selection/document_selection_sliver_app_bar.dart
+++ b/lib/features/documents/view/widgets/selection/document_selection_sliver_app_bar.dart
@@ -1,14 +1,28 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:paperless_mobile/api/paperless_api.dart';
+import 'package:paperless_mobile/constants.dart';
 import 'package:paperless_mobile/core/extensions/context_extensions.dart';
 import 'package:paperless_mobile/core/extensions/document_extensions.dart';
 import 'package:paperless_mobile/core/extensions/flutter_extensions.dart';
+import 'package:paperless_mobile/core/service/file_service.dart';
+import 'package:paperless_mobile/core/store/slices/global_settings.dart';
+import 'package:paperless_mobile/core/widgets/icon_loading_widget.dart';
+import 'package:paperless_mobile/features/document_details/view/dialogs/select_file_type_dialog.dart';
 import 'package:paperless_mobile/features/documents/view/widgets/selection/bulk_delete_confirmation_dialog.dart';
+import 'package:paperless_mobile/features/documents/view/widgets/selection/bulk_download_target_directory_dialog.dart';
+import 'package:paperless_mobile/features/settings/model/file_download_type.dart';
 import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
 import 'package:paperless_mobile/helpers/message_helpers.dart';
+import 'package:paperless_mobile/helpers/permission_helpers.dart';
 import 'package:paperless_mobile/routing/routes/documents_route.dart';
+import 'package:path/path.dart' as p;
+import 'package:permission_handler/permission_handler.dart';
+import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
-class DocumentSelectionSliverAppBar extends StatelessWidget {
+class DocumentSelectionSliverAppBar extends StatefulWidget {
   final Iterable<Document> selection;
   final VoidCallback onResetSelection;
   const DocumentSelectionSliverAppBar({
@@ -18,7 +32,17 @@ class DocumentSelectionSliverAppBar extends StatelessWidget {
   });
 
   @override
+  State<DocumentSelectionSliverAppBar> createState() =>
+      _DocumentSelectionSliverAppBarState();
+}
+
+class _DocumentSelectionSliverAppBarState
+    extends State<DocumentSelectionSliverAppBar> {
+  bool _isBusy = false;
+
+  @override
   Widget build(BuildContext context) {
+    final selection = widget.selection.toList(growable: false);
     return SliverAppBar(
       stretch: false,
       pinned: true,
@@ -28,45 +52,35 @@ class DocumentSelectionSliverAppBar extends StatelessWidget {
       title: Text(S.of(context)!.countSelected(selection.length)),
       leading: IconButton(
         icon: const Icon(Icons.close),
-        onPressed: onResetSelection,
+        onPressed: _isBusy ? null : widget.onResetSelection,
       ),
       actions: [
         IconButton(
-          icon: const Icon(Icons.delete),
-          onPressed: () async {
-            final bulkDelete = context.documentRepository
-                .bulkActionMutation()
-                .mutate;
-
-            final shouldDelete =
-                await showDialog<bool>(
-                  useRootNavigator: false,
-                  context: context,
-                  builder: (context) =>
-                      BulkDeleteConfirmationDialog(selection: selection),
-                ) ??
-                false;
-            if (shouldDelete) {
-              try {
-                await bulkDelete(
-                  BulkEditRequest(
-                    documents: selection.ids,
-                    method: MethodEnum.delete,
-                  ),
-                );
-                if (!context.mounted) return;
-                showSnackBar(
-                  context,
-                  S.of(context)!.documentsSuccessfullyDeleted,
-                );
-                onResetSelection();
-              } on PaperlessApiException catch (error, stackTrace) {
-                if (!context.mounted) return;
-                showErrorMessage(context, error, stackTrace);
-              }
-            }
-          },
+          tooltip: S.of(context)!.shareTooltip,
+          icon: const Icon(Icons.share),
+          onPressed: _isBusy ? null : () => _onShareSelection(selection),
         ),
+        IconButton(
+          tooltip: S.of(context)!.downloadDocumentTooltip,
+          icon: const Icon(Icons.download),
+          onPressed: _isBusy ? null : () => _onDownloadSelection(selection),
+        ),
+        IconButton(
+          tooltip: S.of(context)!.delete,
+          icon: const Icon(Icons.delete),
+          onPressed: _isBusy ? null : () => _onDeleteSelection(selection),
+        ),
+        if (_isBusy)
+          const Padding(
+            padding: EdgeInsets.only(right: 12),
+            child: Center(
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: IconLoadingWidget(),
+              ),
+            ),
+          ),
       ],
       bottom: PreferredSize(
         preferredSize: const Size.fromHeight(kTextTabBarHeight),
@@ -80,10 +94,13 @@ class DocumentSelectionSliverAppBar extends StatelessWidget {
                 avatar: const Icon(Icons.edit),
                 onPressed: () {
                   BulkEditDocumentsRoute(
-                    BulkEditExtraWrapper(selection, LabelType.correspondent),
+                    BulkEditExtraWrapper(
+                      widget.selection,
+                      LabelType.correspondent,
+                    ),
                   ).push<bool>(context).then((wasSuccessful) {
                     if (wasSuccessful ?? false) {
-                      onResetSelection();
+                      widget.onResetSelection();
                     }
                   });
                 },
@@ -93,10 +110,13 @@ class DocumentSelectionSliverAppBar extends StatelessWidget {
                 avatar: const Icon(Icons.edit),
                 onPressed: () async {
                   BulkEditDocumentsRoute(
-                    BulkEditExtraWrapper(selection, LabelType.documentType),
+                    BulkEditExtraWrapper(
+                      widget.selection,
+                      LabelType.documentType,
+                    ),
                   ).push<bool>(context).then((wasSuccessful) {
                     if (wasSuccessful ?? false) {
-                      onResetSelection();
+                      widget.onResetSelection();
                     }
                   });
                 },
@@ -106,10 +126,13 @@ class DocumentSelectionSliverAppBar extends StatelessWidget {
                 avatar: const Icon(Icons.edit),
                 onPressed: () async {
                   BulkEditDocumentsRoute(
-                    BulkEditExtraWrapper(selection, LabelType.storagePath),
+                    BulkEditExtraWrapper(
+                      widget.selection,
+                      LabelType.storagePath,
+                    ),
                   ).push<bool>(context).then((wasSuccessful) {
                     if (wasSuccessful ?? false) {
-                      onResetSelection();
+                      widget.onResetSelection();
                     }
                   });
                 },
@@ -128,13 +151,271 @@ class DocumentSelectionSliverAppBar extends StatelessWidget {
       avatar: const Icon(Icons.edit),
       onPressed: () {
         BulkEditDocumentsRoute(
-          BulkEditExtraWrapper(selection, LabelType.tag),
+          BulkEditExtraWrapper(widget.selection, LabelType.tag),
         ).push<bool>(context).then((wasSuccessful) {
           if (wasSuccessful ?? false) {
-            onResetSelection();
+            widget.onResetSelection();
           }
         });
       },
     );
   }
+
+  Future<void> _onDeleteSelection(List<Document> selection) async {
+    final bulkDelete = context.documentRepository.bulkActionMutation().mutate;
+
+    final shouldDelete =
+        await showDialog<bool>(
+          useRootNavigator: false,
+          context: context,
+          builder: (context) =>
+              BulkDeleteConfirmationDialog(selection: selection),
+        ) ??
+        false;
+    if (!shouldDelete || !mounted) {
+      return;
+    }
+
+    await _runBusyAction(() async {
+      try {
+        await bulkDelete(
+          BulkEditRequest(documents: selection.ids, method: MethodEnum.delete),
+        );
+        if (!mounted) return;
+        showSnackBar(context, S.of(context)!.documentsSuccessfullyDeleted);
+        widget.onResetSelection();
+      } on PaperlessApiException catch (error, stackTrace) {
+        if (!mounted) return;
+        showErrorMessage(context, error, stackTrace);
+      }
+    });
+  }
+
+  Future<void> _onShareSelection(List<Document> selection) async {
+    if (selection.isEmpty) return;
+
+    try {
+      final shareOriginal = await _resolveFileTypeSelection(forSharing: true);
+      if (shareOriginal == null || !mounted) {
+        return;
+      }
+      final hasPermission = await _ensureStoragePermission(forSharing: true);
+      if (!hasPermission || !mounted) {
+        return;
+      }
+      await _runBusyAction(() async {
+        final downloads = await _downloadDocuments(
+          documents: selection,
+          targetDirectoryPath: FileService.instance.temporaryDirectory.path,
+          original: shareOriginal,
+        );
+        if (downloads.isEmpty) {
+          return;
+        }
+        await SharePlus.instance.share(
+          ShareParams(
+            files: downloads
+                .map(
+                  (download) => XFile(
+                    download.file.path,
+                    name: p.basename(download.file.path),
+                    mimeType: shareOriginal
+                        ? download.document.mimeType
+                        : 'application/pdf',
+                    lastModified: download.document.modified,
+                  ),
+                )
+                .toList(),
+            subject: selection.length == 1 ? selection.first.title : null,
+          ),
+        );
+      });
+    } on PaperlessApiException catch (error, stackTrace) {
+      if (!mounted) return;
+      showErrorMessage(context, error, stackTrace);
+    } catch (error) {
+      if (!mounted) return;
+      showGenericError(context, error);
+    }
+  }
+
+  Future<void> _onDownloadSelection(List<Document> selection) async {
+    if (selection.isEmpty) return;
+
+    try {
+      final downloadOriginal = await _resolveFileTypeSelection(
+        forSharing: false,
+      );
+      if (downloadOriginal == null || !mounted) {
+        return;
+      }
+      final hasPermission = await _ensureStoragePermission(forSharing: false);
+      if (!hasPermission || !mounted) {
+        return;
+      }
+      String defaultDirectory = '/storage/emulated/0/Download';
+      try {
+        defaultDirectory = await _resolveDefaultDownloadDirectory();
+      } on Exception {
+        // Keep fallback path.
+      }
+      if (!mounted) {
+        return;
+      }
+      final targetDirectoryPath = await showDialog<String>(
+        useRootNavigator: false,
+        context: context,
+        builder: (context) => BulkDownloadTargetDirectoryDialog(
+          documentsCount: selection.length,
+          initialDirectoryPath: defaultDirectory,
+        ),
+      );
+      if (targetDirectoryPath == null || !mounted) {
+        return;
+      }
+
+      await _runBusyAction(() async {
+        await _downloadDocuments(
+          documents: selection,
+          targetDirectoryPath: targetDirectoryPath,
+          original: downloadOriginal,
+        );
+      });
+      if (!mounted) return;
+      showSnackBar(context, S.of(context)!.notificationDownloadComplete);
+    } on PaperlessApiException catch (error, stackTrace) {
+      if (!mounted) return;
+      showErrorMessage(context, error, stackTrace);
+    } catch (error) {
+      if (!mounted) return;
+      showGenericError(context, error);
+    }
+  }
+
+  Future<bool?> _resolveFileTypeSelection({required bool forSharing}) async {
+    final localStore = context.localStore;
+    final defaultType = forSharing
+        ? localStore.state.globalSettings.defaultShareType
+        : localStore.state.globalSettings.defaultDownloadType;
+    return switch (defaultType) {
+      FileDownloadType.original => true,
+      FileDownloadType.archived => false,
+      FileDownloadType.alwaysAsk => showDialog<bool>(
+        useRootNavigator: false,
+        context: context,
+        builder: (dialogContext) => SelectFileTypeDialog(
+          onRememberSelection: (downloadType) {
+            localStore.updateGlobalSettings(
+              (globalSettings) => forSharing
+                  ? globalSettings.copyWith(defaultShareType: downloadType)
+                  : globalSettings.copyWith(defaultDownloadType: downloadType),
+            );
+          },
+        ),
+      ),
+    };
+  }
+
+  Future<bool> _ensureStoragePermission({required bool forSharing}) async {
+    if (!Platform.isAndroid) {
+      return true;
+    }
+    final sdkInt = androidInfo?.version.sdkInt;
+    if (sdkInt == null) {
+      return true;
+    }
+    final shouldRequestPermission = forSharing ? sdkInt < 30 : sdkInt <= 29;
+    if (!shouldRequestPermission) {
+      return true;
+    }
+    return askForPermission(Permission.storage);
+  }
+
+  Future<String> _resolveDefaultDownloadDirectory() async {
+    return FileService.instance.downloadsDirectory.path;
+  }
+
+  Future<List<_DownloadedDocument>> _downloadDocuments({
+    required Iterable<Document> documents,
+    required String targetDirectoryPath,
+    required bool original,
+  }) async {
+    final api = context.read<PaperlessDocumentsApi>();
+    final targetDirectory = Directory(targetDirectoryPath);
+    await targetDirectory.create(recursive: true);
+
+    final downloadedDocuments = <_DownloadedDocument>[];
+    for (final document in documents) {
+      final targetPath = await _buildUniqueTargetPath(
+        document: document,
+        parentDirectoryPath: targetDirectory.path,
+        original: original,
+      );
+      await api.downloadToFile(document.id, targetPath, original: original);
+      downloadedDocuments.add(_DownloadedDocument(document, File(targetPath)));
+    }
+    return downloadedDocuments;
+  }
+
+  Future<String> _buildUniqueTargetPath({
+    required Document document,
+    required String parentDirectoryPath,
+    required bool original,
+  }) async {
+    final preferredFilename = _sanitizeFilename(
+      document.archivedFileName ??
+          document.originalFileName ??
+          document.title ??
+          'document_${document.id}',
+    );
+
+    final baseName = p.basenameWithoutExtension(preferredFilename).trim();
+    final normalizedBaseName = baseName.isEmpty
+        ? 'document_${document.id}'
+        : baseName;
+    final extension = original ? p.extension(preferredFilename) : '.pdf';
+    final normalizedExtension = extension.isEmpty
+        ? (original ? '.bin' : '.pdf')
+        : extension;
+
+    var candidate = p.join(
+      parentDirectoryPath,
+      '$normalizedBaseName$normalizedExtension',
+    );
+    var copy = 1;
+    while (await File(candidate).exists()) {
+      candidate = p.join(
+        parentDirectoryPath,
+        '${normalizedBaseName}_$copy$normalizedExtension',
+      );
+      copy += 1;
+    }
+    return candidate;
+  }
+
+  String _sanitizeFilename(String input) {
+    return input
+        .replaceAll(RegExp(r'[/\\]'), ' ')
+        .replaceAll(RegExp(r'[:*?"<>|]'), '_')
+        .trim();
+  }
+
+  Future<void> _runBusyAction(Future<void> Function() action) async {
+    if (_isBusy) return;
+    setState(() => _isBusy = true);
+    try {
+      await action();
+    } finally {
+      if (mounted) {
+        setState(() => _isBusy = false);
+      }
+    }
+  }
+}
+
+class _DownloadedDocument {
+  final Document document;
+  final File file;
+
+  const _DownloadedDocument(this.document, this.file);
 }


### PR DESCRIPTION
## Summary

This adds bulk document actions in the Documents tab to match single-document capabilities. (Related to #261 )

### What changed

- Added bulk actions in selection mode:
  - Share selected documents
  - Download selected documents
  - Delete selected documents (with confirmation)
- Added a "select all filtered" action in Documents tab controls so filtered result sets can be bulk-handled.
- Added a folder-target dialog for bulk downloads, including directory picker and confirmation.
- Improved bulk delete confirmation for larger selections (scrollable list + remaining-count indicator).
- Implemented `DocumentRepository.bulkDownload(...)` as API passthrough.

## Behavior

- Multi-selection now supports the same core actions as single document: share, download, delete.
- Filter-based workflows can select all currently filtered documents, then apply those actions.
- Bulk download asks for destination folder before saving files.
- Deletion requires explicit confirmation.

## Validation

- `flutter analyze` on changed files: no issues found.
- Build check: APK build succeeds in this environment.
