### PR TITLE
feat: respect "Full search links to" from UI settings

### DIFF
--- a/lib/api/models/ui_settings_view_settings.dart
+++ b/lib/api/models/ui_settings_view_settings.dart
@@ -15,6 +15,7 @@ abstract class UiSettingsViewSettings with _$UiSettingsViewSettings {
     UiSettingsViewSettingsUpdateChecking? updateChecking,
     UiSettingsViewSettingsPermissions? permissions,
     UiSettingsViewSettingsDateDisplay? dateDisplay,
+    UiSettingsViewSettingsSearch? search,
     bool? auditlogEnabled,
   }) = _UiSettingsViewSettings;
 
@@ -73,4 +74,25 @@ abstract class UiSettingsViewSettingsDateDisplay
   factory UiSettingsViewSettingsDateDisplay.fromJson(
     Map<String, dynamic> json,
   ) => _$UiSettingsViewSettingsDateDisplayFromJson(json);
+}
+
+@JsonEnum(valueField: 'value')
+enum UiSettingsViewSettingsSearchMoreLink {
+  titleContent('title-content'),
+  advanced('advanced');
+
+  final String value;
+  const UiSettingsViewSettingsSearchMoreLink(this.value);
+}
+
+@Freezed(toJson: true, fromJson: true)
+abstract class UiSettingsViewSettingsSearch
+    with _$UiSettingsViewSettingsSearch {
+  factory UiSettingsViewSettingsSearch({
+    @Default(UiSettingsViewSettingsSearchMoreLink.titleContent)
+    UiSettingsViewSettingsSearchMoreLink? moreLink,
+  }) = _UiSettingsViewSettingsSearch;
+
+  factory UiSettingsViewSettingsSearch.fromJson(Map<String, dynamic> json) =>
+      _$UiSettingsViewSettingsSearchFromJson(json);
 }

--- a/lib/features/document_search/view/document_search_page.dart
+++ b/lib/features/document_search/view/document_search_page.dart
@@ -269,7 +269,13 @@ class _DocumentSearchPageState extends State<DocumentSearchPage> {
   Widget _buildResultsView() {
     final normalizedQuery = _searchTerm.trim();
     final resultListQuery = context.documentRepository.getAllQuery(
-      filter: DocumentFilter(query: TextQuery.titleAndContent(normalizedQuery)),
+      filter: DocumentFilter(
+        query:
+            context.uiSettings.settings?.search?.moreLink ==
+                UiSettingsViewSettingsSearchMoreLink.advanced
+            ? TextQuery.extended(normalizedQuery)
+            : TextQuery.titleAndContent(normalizedQuery),
+      ),
     );
 
     final header = Row(


### PR DESCRIPTION
In the Web UI, one can configure the search bar to trigger an advanced search by default, allowing complex expressions as described in https://docs.paperless-ngx.com/usage/#document-searches.

This PR makes the app's search bar follow that setting.

To Test:

- In your browser, open the settings page of your paperless instance
- Under "Global Search", set "Full search links to" to "Advanced"
- Open the app, tap the search bar and enter a complex query such as "foo OR bar"
- Documents containing either "foo" or "bar" will be shown in the search results