### PR TITLE
Expand the camera feature list to make having a camera truly optional

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,15 @@
     <uses-feature
         android:name="android.hardware.camera.any"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.flash"
+        android:required="false" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"


### PR DESCRIPTION
https://github.com/astubenbord/paperless-mobile/pull/639 attempts a fix to https://github.com/astubenbord/paperless-mobile/issues/418 - however, the app still shows up as incompatible on my device (Supernote Nomad) in F-Droid, but this time without a clear indication of why it is incompatible.

_Edit_: Just checked in Aurora and the app is listed there. Makes me wonder if this is not actually an F-Droid bug.

Reading through the Android documentation, including the [CAMERA permission](https://developer.android.com/reference/android/Manifest.permission#CAMERA) implies that `android.hardware.camera` is a required feature. [Reading into this feature](https://developer.android.com/guide/topics/manifest/uses-feature-element#camera-hw-features) it appears this is split over several sub-permissions with a specific recommendation to disable *all* of them to properly list the app for devices without a camera.