### PR TITLE
feat: add Google ML Kit document scanner as alternative scanner engine

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
         android:label="Paperless Mobile"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <!-- Preloads the ML Kit document scanner model on app start to avoid first-scan latency. -->
+        <meta-data
+            android:name="com.google.mlkit.vision.DEPENDENCIES"
+            android:value="docscanner" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/core/store/slices/global_settings.dart
+++ b/lib/core/store/slices/global_settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:paperless_mobile/features/settings/model/color_scheme_option.dart';
 import 'package:paperless_mobile/features/settings/model/file_download_type.dart';
+import 'package:paperless_mobile/features/settings/model/scanner_implementation.dart';
 
 part 'global_settings.g.dart';
 
@@ -22,6 +23,7 @@ class GlobalSettings {
     this.skipDocumentPreprarationOnUpload = false,
     this.disableAnimations = false,
     this.knownHosts = const [],
+    this.preferredScanner = ScannerImplementation.edgeDetection,
   });
 
   final String preferredLocaleSubtag;
@@ -35,6 +37,7 @@ class GlobalSettings {
   final bool skipDocumentPreprarationOnUpload;
   final bool disableAnimations;
   final List<String> knownHosts;
+  final ScannerImplementation preferredScanner;
 
   Map<String, dynamic> toJson() => _$GlobalSettingsToJson(this);
   factory GlobalSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/document_scan/scanner/document_scanner_engine.dart
+++ b/lib/features/document_scan/scanner/document_scanner_engine.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+
+/// Common interface for document scanner engines.
+///
+/// Each implementation launches a scanner UI and returns a list of JPEG files
+/// written to the app's temporary scan directory.
+/// Returns an empty list when the user cancels or no image is captured.
+abstract class DocumentScannerEngine {
+  Future<List<File>> scan();
+}

--- a/lib/features/document_scan/scanner/edge_detection_engine.dart
+++ b/lib/features/document_scan/scanner/edge_detection_engine.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:edge_detection/edge_detection.dart';
+import 'package:paperless_mobile/core/service/file_service.dart';
+import 'package:paperless_mobile/features/document_scan/scanner/document_scanner_engine.dart';
+
+/// Scanner engine backed by the [edge_detection] package.
+///
+/// Opens the native camera UI with automatic edge detection and returns a
+/// single JPEG file. Returns an empty list when the user cancels or the scan
+/// fails.
+class EdgeDetectionEngine implements DocumentScannerEngine {
+  const EdgeDetectionEngine();
+
+  @override
+  Future<List<File>> scan() async {
+    final file = await FileService.instance.allocateTemporaryFile(
+      PaperlessDirectoryType.scans,
+      extension: 'jpeg',
+      create: true,
+    );
+
+    final success = await EdgeDetection.detectEdge(file.path);
+    if (!success) {
+      return [];
+    }
+    return [file];
+  }
+}

--- a/lib/features/document_scan/scanner/mlkit_engine.dart
+++ b/lib/features/document_scan/scanner/mlkit_engine.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:google_mlkit_document_scanner/google_mlkit_document_scanner.dart';
+import 'package:paperless_mobile/core/service/file_service.dart';
+import 'package:paperless_mobile/features/document_scan/scanner/document_scanner_engine.dart';
+
+/// Scanner engine backed by Google ML Kit Document Scanner.
+///
+/// Opens Google's native camera UI with:
+///  - automatic edge detection and perspective correction
+///  - live auto-capture once the document is held steady
+///  - multi-page support (the user can add further pages after each shot)
+///
+/// ML Kit processes images internally (brightness correction, perspective
+/// correction, scan enhancement), so no additional post-processing is needed.
+///
+/// Requires Google Play Services on the device (ML Kit model).
+class MlKitEngine implements DocumentScannerEngine {
+  const MlKitEngine();
+
+  @override
+  Future<List<File>> scan() async {
+    final options = DocumentScannerOptions(
+      // JPEG for compatibility with the rest of the app (cubit, PDF assembly).
+      documentFormats: {DocumentFormat.jpeg},
+      // full = edge detection + auto-capture + image enhancement by ML Kit.
+      mode: ScannerMode.full,
+      // Generous limit; effectively constrained by the scanner UI in practice.
+      pageLimit: 30,
+      // Live camera only — no gallery import.
+      isGalleryImport: false,
+    );
+
+    final scanner = DocumentScanner(options: options);
+    try {
+      final result = await scanner.scanDocument();
+
+      final images = result.images;
+      if (images == null || images.isEmpty) {
+        // User cancelled without capturing a page.
+        return [];
+      }
+
+      final List<File> outputFiles = [];
+      for (final imagePath in images) {
+        // ML Kit already delivers processed JPEGs; copy them into the app's
+        // scan directory so FileService can manage their lifecycle (cleanup on
+        // reset, etc.).
+        final rawBytes = await File(imagePath).readAsBytes();
+        final destFile = await FileService.instance.allocateTemporaryFile(
+          PaperlessDirectoryType.scans,
+          extension: 'jpeg',
+          create: false,
+        );
+        await destFile.writeAsBytes(rawBytes, flush: true);
+        outputFiles.add(destFile);
+      }
+      return outputFiles;
+    } finally {
+      // Release scanner resources on the Dart side.
+      scanner.close();
+    }
+  }
+}

--- a/lib/features/document_scan/view/scanner_page.dart
+++ b/lib/features/document_scan/view/scanner_page.dart
@@ -12,7 +12,6 @@ import 'package:paperless_mobile/core/bloc/loading_status.dart';
 import 'package:paperless_mobile/core/extensions/context_extensions.dart';
 import 'package:paperless_mobile/core/global/constants.dart';
 import 'package:paperless_mobile/core/model/info_message_exception.dart';
-import 'package:paperless_mobile/core/service/file_service.dart';
 import 'package:paperless_mobile/features/app_drawer/view/app_drawer.dart';
 import 'package:paperless_mobile/features/document_scan/cubit/document_scanner_cubit.dart';
 import 'package:paperless_mobile/features/document_scan/scanner/edge_detection_engine.dart';

--- a/lib/features/document_scan/view/scanner_page.dart
+++ b/lib/features/document_scan/view/scanner_page.dart
@@ -2,7 +2,6 @@ import 'dart:developer' as dev;
 import 'dart:io';
 import 'dart:math';
 
-import 'package:edge_detection/edge_detection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -16,11 +15,14 @@ import 'package:paperless_mobile/core/model/info_message_exception.dart';
 import 'package:paperless_mobile/core/service/file_service.dart';
 import 'package:paperless_mobile/features/app_drawer/view/app_drawer.dart';
 import 'package:paperless_mobile/features/document_scan/cubit/document_scanner_cubit.dart';
+import 'package:paperless_mobile/features/document_scan/scanner/edge_detection_engine.dart';
+import 'package:paperless_mobile/features/document_scan/scanner/mlkit_engine.dart';
 import 'package:paperless_mobile/features/document_scan/view/widgets/export_scans_dialog.dart';
 import 'package:paperless_mobile/features/document_scan/view/widgets/scanned_image_item.dart';
 import 'package:paperless_mobile/features/document_search/view/sliver_search_bar.dart';
 import 'package:paperless_mobile/features/document_upload/view/document_upload_preparation_page.dart';
 import 'package:paperless_mobile/features/documents/view/pages/document_view.dart';
+import 'package:paperless_mobile/features/settings/model/scanner_implementation.dart';
 import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
 import 'package:paperless_mobile/helpers/connectivity_aware_action_wrapper.dart';
 import 'package:paperless_mobile/helpers/message_helpers.dart';
@@ -48,40 +50,84 @@ class _ScannerPageState extends State<ScannerPage>
 
   final _scrollController = ScrollController();
 
+  /// True while ML Kit capture and image processing is in progress.
+  bool _isProcessing = false;
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
       top: true,
-      child: Scaffold(
-        drawer: const AppDrawer(),
-        floatingActionButton: FloatingActionButton(
-          heroTag: "fab_document_edit",
-          onPressed: () => _openDocumentScanner(context),
-          child: const Icon(Icons.add_a_photo_outlined),
-        ),
-        body: NestedScrollView(
-          floatHeaderSlivers: true,
-          headerSliverBuilder: (context, innerBoxIsScrolled) => [
-            SliverOverlapAbsorber(
-              handle: searchBarHandle,
-              sliver: SliverSearchBar(titleText: S.of(context)!.scanner),
+      child: Stack(
+        children: [
+          Scaffold(
+            drawer: const AppDrawer(),
+            floatingActionButton: FloatingActionButton.extended(
+              heroTag: "fab_document_edit",
+              onPressed:
+                  _isProcessing ? null : () => _openDocumentScanner(context),
+              icon: _isProcessing
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Icon(Icons.add_a_photo_outlined),
+              label: Text(
+                _isProcessing
+                    ? S.of(context)!.processingScan
+                    : S.of(context)!.scanADocument,
+              ),
             ),
-            SliverOverlapAbsorber(
-              handle: actionsHandle,
-              sliver: SliverPinnedHeader(child: _buildActions()),
+            body: NestedScrollView(
+              floatHeaderSlivers: true,
+              headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                SliverOverlapAbsorber(
+                  handle: searchBarHandle,
+                  sliver: SliverSearchBar(titleText: S.of(context)!.scanner),
+                ),
+                SliverOverlapAbsorber(
+                  handle: actionsHandle,
+                  sliver: SliverPinnedHeader(child: _buildActions()),
+                ),
+              ],
+              body: BlocBuilder<DocumentScannerCubit, DocumentScannerState>(
+                builder: (context, state) {
+                  return switch (state.status) {
+                    LoadingStatus.initial => _buildEmptyState(),
+                    LoadingStatus.loading =>
+                      Center(child: Text("Restoring...")),
+                    LoadingStatus.loaded => _buildImageGrid(state.scans),
+                    LoadingStatus.error => Placeholder(),
+                  };
+                },
+              ),
             ),
-          ],
-          body: BlocBuilder<DocumentScannerCubit, DocumentScannerState>(
-            builder: (context, state) {
-              return switch (state.status) {
-                LoadingStatus.initial => _buildEmptyState(),
-                LoadingStatus.loading => Center(child: Text("Restoring...")),
-                LoadingStatus.loaded => _buildImageGrid(state.scans),
-                LoadingStatus.error => Placeholder(),
-              };
-            },
           ),
-        ),
+          if (_isProcessing)
+            Positioned.fill(
+              child: ColoredBox(
+                color: const Color(0x88000000),
+                child: Center(
+                  child: Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const CircularProgressIndicator(),
+                          const SizedBox(height: 16),
+                          Text(S.of(context)!.processingScan),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -220,33 +266,83 @@ class _ScannerPageState extends State<ScannerPage>
   }
 
   void _openDocumentScanner(BuildContext context) async {
-    final isGranted = await askForPermission(Permission.camera);
-    if (!isGranted) {
-      return;
-    }
-    final file = await FileService.instance.allocateTemporaryFile(
-      PaperlessDirectoryType.scans,
-      extension: 'jpeg',
-      create: true,
-    );
-    if (kDebugMode) {
-      dev.log('[ScannerPage] Created temporary file: ${file.path}');
+    final impl = context.localStore.state.globalSettings.preferredScanner;
+
+    // ML Kit manages its own camera permission through Play Services;
+    // edge_detection still requires an explicit permission request.
+    if (impl == ScannerImplementation.edgeDetection) {
+      final isGranted = await askForPermission(Permission.camera);
+      if (!isGranted) return;
     }
 
-    final success = await EdgeDetection.detectEdge(file.path);
-    if (!success) {
+    if (kDebugMode) {
+      dev.log('[ScannerPage] Using scanner engine: $impl');
+    }
+
+    final engine = switch (impl) {
+      ScannerImplementation.edgeDetection => const EdgeDetectionEngine(),
+      ScannerImplementation.mlKit => const MlKitEngine(),
+    };
+
+    // Show a processing overlay while ML Kit capture + processing runs.
+    if (impl == ScannerImplementation.mlKit && mounted) {
+      setState(() => _isProcessing = true);
+    }
+
+    List<File> scannedFiles;
+    try {
+      scannedFiles = await engine.scan();
+    } finally {
+      if (mounted) setState(() => _isProcessing = false);
+    }
+
+    if (scannedFiles.isEmpty) {
       if (kDebugMode) {
-        dev.log(
-          '[ScannerPage] Scan either not successful or canceled by user.',
-        );
+        dev.log('[ScannerPage] Scan canceled or no images returned.');
       }
       return;
     }
-    if (kDebugMode) {
-      dev.log('[ScannerPage] Wrote image to temporary file: ${file.path}');
-    }
+
     if (!context.mounted) return;
-    context.read<DocumentScannerCubit>().addScan(file);
+
+    if (impl == ScannerImplementation.mlKit) {
+      // ML Kit flow: add pages to the cubit (grid as backup), then immediately
+      // assemble a PDF and open the upload preparation page.
+      final cubit = context.read<DocumentScannerCubit>();
+      for (final file in scannedFiles) {
+        cubit.addScan(file);
+      }
+      if (!context.mounted) return;
+      await _onPrepareDocumentUploadMlKit(context, scannedFiles);
+    } else {
+      // edge_detection flow: add the single image to the grid; the user decides
+      // when to upload.
+      context.read<DocumentScannerCubit>().addScan(scannedFiles.first);
+    }
+
+    if (kDebugMode) {
+      dev.log(
+        '[ScannerPage] Added ${scannedFiles.length} scan(s) from $impl.',
+      );
+    }
+  }
+
+  /// ML Kit variant: always assembles a PDF (regardless of page count) and
+  /// opens the upload preparation page directly.
+  Future<void> _onPrepareDocumentUploadMlKit(
+    BuildContext context,
+    List<File> scans,
+  ) async {
+    final file = await _assembleFileBytes(scans, forcePdf: true);
+    if (!context.mounted) return;
+    final uploadResult = await DocumentUploadRoute(
+      $extra: file.bytes,
+      fileExtension: file.extension,
+    ).push<DocumentUploadResult>(context);
+    if (uploadResult?.success ?? false) {
+      if (!context.mounted) return;
+      context.read<DocumentScannerCubit>().reset();
+    }
   }
 
   void _onPrepareDocumentUpload(BuildContext context, List<File> scans) async {

--- a/lib/features/settings/model/scanner_implementation.dart
+++ b/lib/features/settings/model/scanner_implementation.dart
@@ -1,0 +1,4 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum ScannerImplementation { edgeDetection, mlKit }

--- a/lib/features/settings/view/settings_page.dart
+++ b/lib/features/settings/view/settings_page.dart
@@ -13,6 +13,7 @@ import 'package:paperless_mobile/features/settings/view/widgets/default_download
 import 'package:paperless_mobile/features/settings/view/widgets/default_share_file_type_setting.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/enforce_pdf_upload_setting.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/language_selection_setting.dart';
+import 'package:paperless_mobile/features/settings/view/widgets/scanner_implementation_setting.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/skip_document_prepraration_on_share_setting.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/theme_mode_setting.dart';
 import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
@@ -38,6 +39,7 @@ class SettingsPage extends StatelessWidget {
           const DefaultDownloadFileTypeSetting(),
           const DefaultShareFileTypeSetting(),
           const EnforcePdfUploadSetting(),
+          const ScannerImplementationSetting(),
           const SkipDocumentPreprationOnShareSetting(),
           _buildSectionHeader(context, S.of(context)!.storage),
           const ClearCacheSetting(),

--- a/lib/features/settings/view/widgets/scanner_implementation_setting.dart
+++ b/lib/features/settings/view/widgets/scanner_implementation_setting.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:paperless_mobile/core/extensions/context_extensions.dart';
 import 'package:paperless_mobile/core/store/bloc/global_settings_builder.dart';
+import 'package:paperless_mobile/core/store/slices/global_settings.dart';
 import 'package:paperless_mobile/features/settings/model/scanner_implementation.dart';
 import 'package:paperless_mobile/features/settings/view/widgets/radio_settings_dialog.dart';
 import 'package:paperless_mobile/generated/l10n/app_localizations.dart';

--- a/lib/features/settings/view/widgets/scanner_implementation_setting.dart
+++ b/lib/features/settings/view/widgets/scanner_implementation_setting.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:paperless_mobile/core/extensions/context_extensions.dart';
+import 'package:paperless_mobile/core/store/bloc/global_settings_builder.dart';
+import 'package:paperless_mobile/features/settings/model/scanner_implementation.dart';
+import 'package:paperless_mobile/features/settings/view/widgets/radio_settings_dialog.dart';
+import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
+
+class ScannerImplementationSetting extends StatelessWidget {
+  const ScannerImplementationSetting({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final localStore = context.localStore;
+    return GlobalSettingsBuilder(
+      builder: (context, settings) => ListTile(
+        title: Text(S.of(context)!.scannerEngine),
+        subtitle: Text(_label(context, settings.preferredScanner)),
+        onTap: () async {
+          final selected = await showDialog<ScannerImplementation>(
+            useRootNavigator: false,
+            context: context,
+            builder: (context) => RadioSettingsDialog<ScannerImplementation>(
+              titleText: S.of(context)!.scannerEngine,
+              options: [
+                RadioOption(
+                  value: ScannerImplementation.edgeDetection,
+                  label: _label(context, ScannerImplementation.edgeDetection),
+                ),
+                RadioOption(
+                  value: ScannerImplementation.mlKit,
+                  label: _label(context, ScannerImplementation.mlKit),
+                ),
+              ],
+              initialValue: settings.preferredScanner,
+            ),
+          );
+          if (selected != null) {
+            localStore.updateGlobalSettings(
+              (s) => s.copyWith(preferredScanner: selected),
+            );
+          }
+        },
+      ),
+    );
+  }
+
+  String _label(BuildContext context, ScannerImplementation impl) {
+    return switch (impl) {
+      ScannerImplementation.edgeDetection =>
+        S.of(context)!.scannerEngineEdgeDetection,
+      ScannerImplementation.mlKit => S.of(context)!.scannerEngineMlKit,
+    };
+  }
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -993,6 +993,22 @@
   "@scanADocument": {},
   "scanner": "Scanner",
   "@scanner": {},
+  "scannerEngine": "Document scanner",
+  "@scannerEngine": {
+    "description": "Title for the document scanner engine selection setting."
+  },
+  "scannerEngineEdgeDetection": "Legacy (edge detection)",
+  "@scannerEngineEdgeDetection": {
+    "description": "Label for the edge_detection scanner engine option."
+  },
+  "scannerEngineMlKit": "New (ML Kit · multi-page · auto-enhance)",
+  "@scannerEngineMlKit": {
+    "description": "Label for the Google ML Kit document scanner engine option."
+  },
+  "processingScan": "Processing scan…",
+  "@processingScan": {
+    "description": "Label shown on the FAB and processing overlay while ML Kit capture and processing is running."
+  },
   "scrollToTop": "Scroll to top",
   "@scrollToTop": {},
   "search": "Search",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
     git:
       url: https://github.com/sawankumarbundelkhandi/edge_detection
       ref: master
+  google_mlkit_document_scanner: ^0.5.0
   path_provider: ^2.0.10
   image: ^4.0.17
   photo_view: ^0.15.0


### PR DESCRIPTION
## Summary

Adds Google ML Kit Document Scanner as an optional alternative to the existing edge_detection-based scanner. Users can now choose their preferred scanner engine in the app settings.

**Changes:**
- Introduces a `DocumentScannerEngine` abstraction with a common `scan()` interface
- Adds `MlKitEngine` backed by `google_mlkit_document_scanner` with full mode (edge detection, auto-capture, image enhancement)
- Wraps the existing edge_detection logic in `EdgeDetectionEngine`
- Adds a "Scanner Engine" setting in the settings page (persisted via `global_settings`)
- ML Kit engine supports multi-page scanning (up to 30 pages per session)
- Requires Google Play Services (ML Kit model)

## Motivation

The existing edge_detection scanner requires manual shutter press and has limited image enhancement. ML Kit provides automatic edge detection, perspective correction, live auto-capture, and built-in image enhancement — useful for users who scan frequently or need better scan quality.

## Notes

- Users who don't have Google Play Services will see the existing scanner as the only option (or the setting will not function — needs testing on de-Googled devices)


<img width="924" height="2048" alt="image3" src="https://github.com/user-attachments/assets/ab2f4178-c7aa-427c-bfd0-3c0dd78c2421" />
<img width="924" height="2048" alt="image2" src="https://github.com/user-attachments/assets/e44e99e8-8354-4a9e-a627-c50316f0cd0d" />
<img width="924" height="2048" alt="image1" src="https://github.com/user-attachments/assets/4f1e07f9-bdd8-44d9-8c25-fcc4969bf780" />
