### PR TITLE
fix: retain keyboard focus in date input by not doing intermittent validation

### DIFF
--- a/lib/core/widgets/form_builder_fields/form_builder_localized_date_picker.dart
+++ b/lib/core/widgets/form_builder_fields/form_builder_localized_date_picker.dart
@@ -355,7 +355,6 @@ class _FormBuilderLocalizedDatePickerState
             _DateInputSegment.year => fieldValue.copyWith(year: number),
           };
           field.setValue(newValue);
-          field.validate();
         }
       },
       inputFormatters: [

--- a/test/src/form_builder_localized_date_picker_test.dart
+++ b/test/src/form_builder_localized_date_picker_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paperless_mobile/api/paperless_api.dart';
+import 'package:paperless_mobile/core/store/slices/local_user_account.dart';
+import 'package:paperless_mobile/core/store/slices/user_profile.dart';
+import 'package:paperless_mobile/core/widgets/form_builder_fields/form_builder_localized_date_picker.dart';
+import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  testWidgets(
+    'advances focus without validating an incomplete date',
+    (tester) async {
+      await tester.pumpWidget(
+        Provider.value(
+          value: LocalUserAccount(
+            appUserId: 'test',
+            serverUrl: 'https://example.com',
+            apiVersion: 9,
+            profile: UserProfile(
+              profile: Profile(),
+              uiSettings: UiSettingsView(
+                user: UiSettingsViewUser(id: 1, username: 'test'),
+              ),
+            ),
+          ),
+          child: MaterialApp(
+            localizationsDelegates: S.localizationsDelegates,
+            supportedLocales: S.supportedLocales,
+            home: Scaffold(
+              body: FormBuilder(
+                child: FormBuilderLocalizedDatePicker(
+                  name: 'created',
+                  labelText: 'Created at',
+                  firstDate: DateTime(1000, 1, 1),
+                  lastDate: DateTime(9999, 12, 31),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(TextFormField).at(0));
+      await tester.enterText(find.byType(TextFormField).at(0), '12');
+      await tester.pump();
+
+      final secondInput = tester.widget<EditableText>(
+        find.byType(EditableText).at(1),
+      );
+      expect(secondInput.focusNode.hasFocus, isTrue);
+      expect(find.text('This field is required.'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
When entering "Creation at" (or any other date, but this was the one I was concerned with) the keyboard focus would get removed after entering the first segment, and the field will be marked as invalid with "Value is required".

Removing the premature validation allows keyboard focus to naturally flow into next field.

Disclaimer: Not a flutter developer, the test was vibe-coded.