### PR TITLE
fix: Use correct translation keys for labels in storage-path "added"-variables input chips

### DIFF
--- a/lib/features/labels/storage_path/view/widgets/storage_path_autofill_form_builder_field.dart
+++ b/lib/features/labels/storage_path/view/widgets/storage_path_autofill_form_builder_field.dart
@@ -121,26 +121,26 @@ class _StoragePathAutofillFormBuilderFieldState
                 onPressed: () => _addParameterToInput("{created_day}", field),
               ),
               InputChip(
-                label: Text(S.of(context)!.createdAt),
+                label: Text(S.of(context)!.addedAt),
                 onPressed: () => _addParameterToInput("{added}", field),
               ),
               InputChip(
                 label: Text(
-                  "${S.of(context)!.createdAt}"
+                  "${S.of(context)!.addedAt}"
                   " (${S.of(context)!.storagePathYear})",
                 ),
                 onPressed: () => _addParameterToInput("{added_year}", field),
               ),
               InputChip(
                 label: Text(
-                  "${S.of(context)!.createdAt}"
+                  "${S.of(context)!.addedAt}"
                   " (${S.of(context)!.storagePathMonth})",
                 ),
                 onPressed: () => _addParameterToInput("{added_month}", field),
               ),
               InputChip(
                 label: Text(
-                  "${S.of(context)!.createdAt} (${S.of(context)!.storagePathDay})",
+                  "${S.of(context)!.addedAt} (${S.of(context)!.storagePathDay})",
                 ),
                 onPressed: () => _addParameterToInput("{added_day}", field),
               ),


### PR DESCRIPTION
The labels of the input chips for the "added"-variables (`{added}`, `{added_year}`, `{added_month}`, `{added_day}`) used the wrong translation key (`createdAt` instead of `addedAt`).
The path variables input chips, when building a storage path, showed the same labels for "created"-variables and "added"-variables respectively.