### PR TITLE
feat: respect system HTTP proxy

### DIFF
--- a/lib/core/security/system_http_proxy.dart
+++ b/lib/core/security/system_http_proxy.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:native_flutter_proxy/native_flutter_proxy.dart';
+import 'package:paperless_mobile/features/logging/data/logger.dart';
+
+/// Process-wide system HTTP proxy applied to every dart:io [HttpClient]
+/// (including Dio) via [HttpOverrides].
+///
+/// Dart does not read Android/iOS system proxy settings on its own.
+/// Native config is stored here; [findProxy] runs per request so a later
+/// system-proxy change is picked up by already-created clients.
+abstract final class SystemHttpProxy {
+  static String? host;
+  static int? port;
+
+  static bool get isConfigured {
+    final configuredHost = host;
+    final configuredPort = port;
+    return configuredHost != null &&
+        configuredHost.isNotEmpty &&
+        configuredPort != null &&
+        configuredPort > 0;
+  }
+
+  static void apply({required String? host, required int? port}) {
+    SystemHttpProxy.host = host;
+    SystemHttpProxy.port = port;
+  }
+
+  static void clear() {
+    host = null;
+    port = null;
+  }
+
+  /// PAC-style proxy string for [HttpClient.findProxy].
+  static String findProxy(Uri uri) {
+    if (_isLoopback(uri.host)) {
+      return 'DIRECT';
+    }
+    if (isConfigured) {
+      return 'PROXY $host:$port';
+    }
+    return HttpClient.findProxyFromEnvironment(uri);
+  }
+
+  static bool _isLoopback(String host) {
+    if (host.isEmpty) {
+      return false;
+    }
+    if (host.toLowerCase() == 'localhost') {
+      return true;
+    }
+    return InternetAddress.tryParse(host)?.isLoopback ?? false;
+  }
+
+  /// Socket destination for [HttpClient.connectionFactory].
+  ///
+  /// When a proxy is set, connect to the proxy only. Dart's default client
+  /// DNS-looks up the request host first, which hangs on networks that only
+  /// resolve through the proxy.
+  static ({String host, int port, bool tlsToTarget}) socketTarget(
+    Uri uri,
+    String? proxyHost,
+    int? proxyPort,
+  ) {
+    if (proxyHost != null &&
+        proxyHost.isNotEmpty &&
+        proxyPort != null &&
+        proxyPort > 0) {
+      return (host: proxyHost, port: proxyPort, tlsToTarget: false);
+    }
+    final isSecure = uri.isScheme('https');
+    var port = uri.port;
+    if (port == 0) {
+      port = isSecure
+          ? HttpClient.defaultHttpsPort
+          : HttpClient.defaultHttpPort;
+    }
+    return (host: uri.host, port: port, tlsToTarget: isSecure);
+  }
+}
+
+/// Installs [HttpOverrides.global] and reads the OS proxy.
+///
+/// Must run after [logger] is initialized and before the first HTTP request.
+/// PAC-based Android proxies arrive via
+/// [NativeProxyReader.setProxyChangedCallback], not the initial read.
+Future<void> installSystemHttpProxy() async {
+  HttpOverrides.global = SystemHttpProxyOverrides();
+  try {
+    _applyNativeSetting(await NativeProxyReader.proxySetting);
+    NativeProxyReader.setProxyChangedCallback((settings) async {
+      _applyNativeSetting(settings);
+    });
+  } on MissingPluginException {
+    // Tests and platforms without the plugin still honor http_proxy env vars.
+  } catch (error, stackTrace) {
+    logger.fe(
+      'Failed to read system HTTP proxy.',
+      className: 'SystemHttpProxy',
+      methodName: 'installSystemHttpProxy',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+}
+
+void _applyNativeSetting(ProxySetting settings) {
+  if (settings.enabled) {
+    SystemHttpProxy.apply(host: settings.host, port: settings.port);
+    logger.fi(
+      'Using system HTTP proxy ${settings.host}:${settings.port}',
+      className: 'SystemHttpProxy',
+      methodName: '_applyNativeSetting',
+    );
+  } else {
+    if (SystemHttpProxy.isConfigured) {
+      logger.fi(
+        'Cleared system HTTP proxy.',
+        className: 'SystemHttpProxy',
+        methodName: '_applyNativeSetting',
+      );
+    }
+    SystemHttpProxy.clear();
+  }
+}
+
+class SystemHttpProxyOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return super.createHttpClient(context)
+      ..findProxy = SystemHttpProxy.findProxy
+      ..connectionFactory = (uri, proxyHost, proxyPort) {
+        final target = SystemHttpProxy.socketTarget(uri, proxyHost, proxyPort);
+        if (target.tlsToTarget) {
+          // DIRECT https: dart:io has no getter for badCertificateCallback,
+          // so this path uses default cert checks. Proxied https still uses
+          // the client's callback inside CONNECT/TLS (SessionManager sets it).
+          return SecureSocket.startConnect(
+            target.host,
+            target.port,
+            context: context,
+          );
+        }
+        return Socket.startConnect(target.host, target.port);
+      };
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:paperless_mobile/core/exception/server_message_exception.dart';
 import 'package:paperless_mobile/core/interceptor/language_header.interceptor.dart';
 import 'package:paperless_mobile/core/security/session_manager.dart';
 import 'package:paperless_mobile/core/security/session_manager_impl.dart';
+import 'package:paperless_mobile/core/security/system_http_proxy.dart';
 import 'package:paperless_mobile/core/service/connectivity_status_service.dart';
 import 'package:paperless_mobile/core/service/file_service.dart';
 import 'package:paperless_mobile/core/store/bloc/global_settings_builder.dart';
@@ -98,6 +99,7 @@ void main() async {
       final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
       final defaultLocale = defaultPreferredLocale.languageCode;
       await initializeDefaultParameters();
+      await installSystemHttpProxy();
       CachedQuery.instance.configFlutter(
         config: GlobalQueryConfig(
           refetchOnConnection: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1157,6 +1157,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.5.1"
+  native_flutter_proxy:
+    dependency: "direct main"
+    description:
+      name: native_flutter_proxy
+      sha256: "35f1a3c8993ad4dfc0ed67637fb4562ee6c307b785d27abc04cd6a21abcab014"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   flutter_colorpicker: ^1.0.3
   provider: ^6.0.5
   dio: ^5.9.0
+  native_flutter_proxy: ^0.3.1
   hydrated_bloc: ^10.1.1
   json_annotation: ^4.9.0
   pretty_dio_logger: ^1.4.0

--- a/test/src/system_http_proxy_test.dart
+++ b/test/src/system_http_proxy_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paperless_mobile/core/security/system_http_proxy.dart';
+
+void main() {
+  tearDown(SystemHttpProxy.clear);
+
+  test('loopback is always DIRECT', () {
+    SystemHttpProxy.apply(host: '10.0.0.1', port: 8080);
+
+    expect(
+      SystemHttpProxy.findProxy(Uri.parse('https://localhost/api/')),
+      'DIRECT',
+    );
+    expect(
+      SystemHttpProxy.findProxy(Uri.parse('http://127.0.0.1:3131/api/')),
+      'DIRECT',
+    );
+    expect(
+      SystemHttpProxy.findProxy(
+        Uri(scheme: 'https', host: '::1', path: '/api/'),
+      ),
+      'DIRECT',
+    );
+  });
+
+  test('configured native proxy is used for remote hosts', () {
+    SystemHttpProxy.apply(host: '10.0.0.1', port: 8080);
+
+    expect(
+      SystemHttpProxy.findProxy(Uri.parse('https://paperless.example/api/')),
+      'PROXY 10.0.0.1:8080',
+    );
+  });
+
+  test('cleared proxy falls back to environment (DIRECT when unset)', () {
+    SystemHttpProxy.apply(host: '10.0.0.1', port: 8080);
+    SystemHttpProxy.clear();
+
+    expect(
+      SystemHttpProxy.findProxy(Uri.parse('https://paperless.example/api/')),
+      'DIRECT',
+    );
+  });
+
+  test('socketTarget uses proxy host without looking up the request host', () {
+    final target = SystemHttpProxy.socketTarget(
+      Uri.parse('https://paperless.example/api/'),
+      '10.0.0.1',
+      8080,
+    );
+
+    expect(target.host, '10.0.0.1');
+    expect(target.port, 8080);
+    expect(target.tlsToTarget, isFalse);
+  });
+
+  test('socketTarget DIRECT https uses 443 and TLS to the request host', () {
+    final target = SystemHttpProxy.socketTarget(
+      Uri.parse('https://paperless.example/api/'),
+      null,
+      null,
+    );
+
+    expect(target.host, 'paperless.example');
+    expect(target.port, 443);
+    expect(target.tlsToTarget, isTrue);
+  });
+}


### PR DESCRIPTION
Dio uses dart:io `HttpClient`, which only honors `http_proxy` from the process environment. Android/iOS system proxy (Wi-Fi manual proxy, PAC, `settings put global http_proxy`) never reached API traffic, so the app could not reach a Paperless server that the browser could.

This PR reads the OS proxy via `native_flutter_proxy` (reader only) and installs `HttpOverrides` so every `HttpClient` — including Dio — uses it. Loopback stays `DIRECT`. When a proxy is set, sockets connect to the proxy first so dart:io does not DNS-look up the request host on networks that only resolve through the proxy.

**Tested:** Samsung SM-F956B (Android 16), PAC-injected `127.0.0.1:34679`. Cold `flutter run`: `Using system HTTP proxy 127.0.0.1:34679`, then `HEAD /api/schema/` 200 and login 200.

To test:

- Point the device at a HTTP proxy the browser already uses (Wi-Fi proxy or PAC)
- Full process restart (hot reload can miss the native plugin)
- Log in against a Paperless URL that is only reachable through that proxy
- Confirm log line `Using system HTTP proxy host:port` and a 200 on `/api/schema/`